### PR TITLE
u-boot: patches: fix load of DTB for legacy r1+ devices

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0003-rockchip-common-configure-boot-commands-and-apparmor.patch
+++ b/recipes-bsp/u-boot/u-boot/0003-rockchip-common-configure-boot-commands-and-apparmor.patch
@@ -15,7 +15,7 @@ diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common
 index e5b8368..5c45f00 100644
 --- a/include/configs/rockchip-common.h
 +++ b/include/configs/rockchip-common.h
-@@ -135,15 +135,12 @@
+@@ -135,15 +135,13 @@
  		"setenv devtype ramdisk; setenv devnum 0;" \
  	"fi; \0"
  
@@ -33,6 +33,7 @@ index e5b8368..5c45f00 100644
 +	ext2load mmc 1:3 0x00280000 Image-initramfs-orangepi-r1plus-lts.bin; \
 +	ext2load mmc 1:3 0x00280000 Image-initramfs-orangepi-r1plus.bin; \
 +	ext2load mmc 1:3 0x08300000 rk3328-orangepi-r1-plus-lts.dtb; \
++	ext2load mmc 1:3 0x08300000 rk3328-orangepi-r1-plus.dtb; \
 +	booti 0x00280000 - 0x08300000;"
  
  #endif /* CONFIG_SPL_BUILD */


### PR DESCRIPTION
The devicetree from legacy r1+ devices was not loaded at all in uboot...